### PR TITLE
Updates FFXIV cactpot solver source link to new repo

### DIFF
--- a/apps-toolchainless/ffxiv-mini-cactpot-solver/index.html
+++ b/apps-toolchainless/ffxiv-mini-cactpot-solver/index.html
@@ -6,7 +6,7 @@ Author:   simshadows <contact@simshadows.com>
 License:  GNU Affero General Public License v3 (AGPL-3.0)
 
 Full source code is available here:
-<https://github.com/simshadows/random-scripts-and-programs/tree/master/web-apps/2022-01-21_ffxiv-cactpot-solver>
+<https://github.com/simshadows/small-web-apps-collection/tree/master/apps-toolchainless/ffxiv-mini-cactpot-solver>
 -->
 
 <html>


### PR DESCRIPTION
Old link as deployed in source of https://apps.simshadows.com/ffxiv-mini-cactpot-solver/ is dead - this PR updates to the seemingly new home of it